### PR TITLE
fixed apply function

### DIFF
--- a/src/jobs/jobs-router.js
+++ b/src/jobs/jobs-router.js
@@ -73,7 +73,7 @@ jobsRouter
             total_salary,
             job_school_id
         }
-        console.log('request body', req.body)
+
         for (const [key, value] of Object.entries(newJob))
             if (value === '')
                 return res.status(400).json({

--- a/src/jobs/jobs-service.js
+++ b/src/jobs/jobs-service.js
@@ -1,6 +1,7 @@
 const JobsService = {
     getAllJobs(knex) {
         return knex.from('everest_jobs')
+            .select('everest_jobs.id as job_id')
             .select('*')
             .join('everest_schools', 'everest_schools.id', '=', 'everest_jobs.job_school_id')
             .select('location')
@@ -17,6 +18,7 @@ const JobsService = {
     getById(knex, id) {
         return knex
             .from('everest_jobs')
+            .select('everest_jobs.id as job_id')
             .select('*')
             .where('id', id)
             .first()
@@ -36,7 +38,7 @@ const JobsService = {
 
     serializeJob(job) {
         return {
-            job_id: job.id,
+            job_id: job.job_id,
             school_id: job.job_school_id,
             job_title: job.job_title,
             course: job.course,


### PR DESCRIPTION
- fixed join method in  for jobs-service to avoid overwriting; prior to the fix, three different jobs had the same job_id because job_id was in fact alias for school_id.
- added an alias for method getById to avoid being filtered by serializeJob 